### PR TITLE
Fix whitespace issues and dynamically generate the local URL

### DIFF
--- a/ApiSpec/TestData/load-all.sh
+++ b/ApiSpec/TestData/load-all.sh
@@ -1,4 +1,4 @@
-#$/bin/bash
+#!/bin/bash
 
 if [ -z "$1" ]; then
   echo Incorrect syntax

--- a/ApiSpec/TestData/load.sh
+++ b/ApiSpec/TestData/load.sh
@@ -1,6 +1,5 @@
-#$/bin/bash
-
-local=http://frontend-tran-schoolbus-dev.10.0.75.2.nip.io
+#!/bin/bash
+local=http://$(oc get routes | grep frontend | awk '{printf $2}')
 dev=http://server-tran-schoolbus-dev.pathfinder.gov.bc.ca
 test=http://server-tran-schoolbus-test.pathfinder.gov.bc.ca
 
@@ -33,4 +32,4 @@ fi
 # fi
 
 echo Loading File ${1} using endpoint ${server}/${2}
-curl -b cookie -v -H "Content-Type: application/json" -X POST --data-binary "@${1}" ${server}/${2}
+curl -b cookie -v -H "Content-Type: application/json" --data-binary "@${1}" ${server}/${2}

--- a/SiteMinder-Proxy/conf.d/server.conf
+++ b/SiteMinder-Proxy/conf.d/server.conf
@@ -26,6 +26,10 @@ server {
         
         # its helpful to cache these responses
         proxy_cache globalcache;
+
+        # Bulk actions like loading sample data take a lot longer than
+        # you'd hope on this stack:
+        proxy_read_timeout 1200s;
     }
     
     # For status of ngnix service

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,41 @@
+# Demo
+
+
+## Prerequisites
+
+### Docker
+
+Install the CLI utility
+
+    brew install docker
+
+Then install the docker client:
+
+<https://www.docker.com/docker-mac>
+
+
+### Openshift 3
+
+    brew install openshift-cli
+
+
+## Setup
+
+### Docker
+
+1.  Insecure Registries
+
+    In your docker client preferences, under the daemon section, add 172.30.0.0/16 to the list of insecure registries.
+
+2.  Docker Resources
+
+    In your docker client preferences, under the advanced section, set Memory to 4gb.
+
+## Running
+
+To generate all the files necessary to spin up a fresh demo instance, run the demo script below.
+
+    ./demo.sh
+
+Note: If you're running this script for the first time, the process can be quite lengthy. On a 2015 Macbook Pro, it 30 minutes to pull down and build all the necessary images.
+

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Execute all commands in root directory
+cd ..
+
+if ! hash oc 2>/dev/null; then
+  printf "Please install openshift-cli. Example: \nbrew install openshift-cli";
+  exit
+fi
+
+echo "Starting up oc cluster and logging you in"
+oc cluster up
+
+if [ "$?" -ne "0" ]; then
+  exit
+fi
+
+oc login --username=developer --password=anypassword
+
+# Create both projects
+oc new-project tran-schoolbus-dev
+oc new-project tran-schoolbus-tools
+
+# Generate build template
+oc process -f openshift/templates/schoolbus-build-template.json > schoolbus-build.json
+
+# Create open shift resources
+oc create -f schoolbus-build.json
+
+echo "Building resources, this could take awhile"
+oc get is
+
+pods_built=$(oc get is | grep -c "latest")
+start_time=$(date +"%s")
+max_time=$(expr $start_time + 2700)
+while [ "$pods_built" -lt "11" ]; do
+  current_time=$(date +"%s")
+  if [ "$current_time" -gt "$max_time" ]; then
+    echo -e "\nProcess looks to be taking longer than expected."
+    echo "Open up the admin web page and check for problems."
+    exit
+  fi
+  echo -n "."
+  sleep 3
+  pods_built=$(oc get is | grep -c "latest")
+done
+
+echo "Tagging the dev applications..."
+
+oc tag backup:latest backup:dev;oc tag client:latest client:dev;oc tag frontend:latest frontend:dev;oc tag mock:latest mock:dev;oc tag pdf:latest pdf:dev;oc tag s2i-nginx:latest s2i-nginx:dev;oc tag schema-spy:latest schema-spy:dev;oc tag server:latest server:dev;oc tag cerberus:latest cerberus:dev
+
+echo "Setting permissions"
+
+oc policy add-role-to-user system:image-puller system:serviceaccount:tran-schoolbus-dev:default -n tran-schoolbus-tools
+
+oc project tran-schoolbus-dev
+
+#copyign secrets over
+current_directory=$PWD
+mkdir /tmp/schoolbus
+mkdir /tmp/schoolbus/secrets
+
+cp ApiSpec/TestData/example_ccw.json /tmp/schoolbus/ccw.json
+cp ApiSpec/TestData/example_users.json /tmp/schoolbus/secrets/users.json
+cp ApiSpec/TestData/Regions/Regions_Region.json /tmp/schoolbus/secrets/regions.json
+cp ApiSpec/TestData/Districts/Districts_District.json /tmp/schoolbus/secrets/districts.json
+
+oc secrets new ccw-secret /tmp/schoolbus/ccw.json
+oc secrets new schoolbus-secret /tmp/schoolbus/secrets
+
+# Create deployment template
+oc process -f openshift/templates/schoolbus-deployment-template.json >schoolbus-deployment.json
+oc create -f schoolbus-deployment.json # Use same as output file in the previous command
+
+# Delete postgres service, probably should find out why it needs to be deleted
+oc delete dc postgresql
+oc delete service postgresql
+
+# Pull down image
+# docker pull centos/postgresql-95-centos7
+
+#get main server name
+pg_user=$(oc env dc/server --list| grep POSTGRESQL_USER)
+pg_user=${pg_user#*=}
+pg_password=$(oc env dc/server --list | grep POSTGRESQL_PASSWORD)
+pg_password=${pg_password#*=}
+
+oc new-app postgresql \
+   -e POSTGRESQL_USER=$pg_user \
+   -e POSTGRESQL_PASSWORD=$pg_password \
+   -e POSTGRESQL_DATABASE=schoolbus
+
+# Generate route
+oc expose service frontend
+
+# Parse route
+frontend="http://$(oc get routes | grep frontend | awk '{printf $2}')"
+
+
+# Generating data
+cd ./ApiSpec/TestData/
+./load-all.sh "local"
+
+# Getting auth token and then loading up main app
+echo $frontend/api/authentication/dev/token/
+
+if [ $uname="Darwin" ]; then
+  echo -e "\n\nAuthorizing with dev token\n user"
+  open $frontend/api/authentication/dev/token/SCURRAN
+fi
+
+sleep 3
+echo $frontend
+
+if [ $uname="Darwin" ]; then
+  echo "Loading app"
+  open $frontend
+fi


### PR DESCRIPTION
When running the load-all.sh and load.sh scripts, they would fail due to DOS/Windows carriage return and Line Feed whitepace character.

Additionally, we've added the ability to dynamically generate the "local" url in load.sh, as that is something OpenShift generates based on the user's OS and setting.