### PR TITLE
Add history log to record primary contact change

### DIFF
--- a/Client/src/js/api.js
+++ b/Client/src/js/api.js
@@ -885,6 +885,8 @@ export function addContact(contact){
     parseContact(contact);
 
     store.dispatch({ type: Action.ADD_CONTACT, contact: contact });
+
+    return response;
   });
 }
 

--- a/Client/src/js/history.js
+++ b/Client/src/js/history.js
@@ -34,9 +34,9 @@ export const OWNER_REMOVED_BUS = 'A school bus was removed from Owner %e - Schoo
 export const OWNER_CONTACT_ADDED = 'Owner %e - Contact of %e was added.';
 export const OWNER_CONTACT_MODIFIED = 'Owner %e - Contact of %e was modified.';
 export const OWNER_CONTACT_DELETED = 'Owner %e - Contact of %e was deleted.';
-export const OWNER_ADDED_PRIMARY_CONTACT = 'Owner %e - Set contact %e as new primary contact.';
-export const OWNER_UPDATE_PRIMARY_CONTACT = 'Owner %e - Updated conatact %e as new primary contact.';
-export const OWNER_DELETED_PRIMARY_CONTACT = 'Owner %e - Set primary contact %e to non-primary.';
+export const OWNER_ADDED_PRIMARY_CONTACT = 'Owner %e - Set new contact %e as primary contact.';
+export const OWNER_UPDATE_PRIMARY_CONTACT = 'Owner %e - Updated contact %e to primary contact.';
+export const OWNER_DESELECTED_PRIMARY_CONTACT = 'Owner %e - Changed primary contact %e to non-primary.';
 
 export const USER_ADDED = 'User %e was added.';
 export const USER_MODIFIED = 'User %e was modified.';
@@ -259,6 +259,6 @@ export function logModifiedPrimaryContact(owner, contact){
   log(owner.historyEntity, OWNER_UPDATE_PRIMARY_CONTACT, contact.historyEntity);
 }
 
-export function logSetNonPrimaryContact(owner, contact){
-  log(owner.historyEntity, OWNER_DELETED_PRIMARY_CONTACT, contact.historyEntity);
+export function logDeselectedPrimaryContact(owner, contact){
+  log(owner.historyEntity, OWNER_DESELECTED_PRIMARY_CONTACT, contact.historyEntity);
 }


### PR DESCRIPTION
1. Client/src/js/api.js, return the new added contact object.
2. Client/src/js/history.js, change wordings that show on the history log.
3. Client/src/js/views/OwnersDetail.jsx.
    a. lines 180-186, delete getContacts, reuse fetch() instead (line 241). fetch() was already there before I worked on  
        this ticket.
    b. line 204, condition that will be triggered when set to new primary contact from no primary contact and switch primary contact. Update primary contact history log will record this change.
    c. line 206-208, condition that decide if user deselect the primary contact.
    d. line 212-215, update primary contact.
    e. line 226-238, History. methods are for applying history logs. Update new contact to primary if condition is met.
