### PR TITLE
SB-375 Interface Stops Responding After Searching With too many cities

### DIFF
--- a/Client/src/js/views/TopNav.jsx
+++ b/Client/src/js/views/TopNav.jsx
@@ -26,7 +26,17 @@ var TopNav = React.createClass({
   render: function () {
     let isCurrentUserAdmin = this.getIsCurrentUserAdmin();
     var requestError = this.props.requestError;
-    var html = requestError.html ? JSON.parse(requestError.html) : null;
+    var html;
+
+    if (requestError.html){
+      try {
+        html = JSON.parse(requestError.html);
+      } catch (e) {
+        console.log(requestError.html);
+        html = { errorTitle: 'Error', errorMessage: 'Internal error'};
+      }
+    }
+
     var errorTitle = html ? html.errorTitle : '';
     var errorMessage = html ? html.errorMessage : '';
 


### PR DESCRIPTION
When the query string is too long, the server responds with html content which causes an exception when trying to parse the html into JSON and causes React crash and eventually the client stops responding. This commit fixes the issue by handling the exception and make the client show the error and keep responding afterwards.